### PR TITLE
Revert "Address #291; Use fcrepo-webapp-plus instead of fcrepo-webapp."

### DIFF
--- a/Dockerfile.open-jdk
+++ b/Dockerfile.open-jdk
@@ -15,7 +15,7 @@ ENV FEDORA_HOME="/mnt/fedora-data" \
 RUN mkdir -p ${FEDORA_HOME} && \
     chown tomcat:tomcat ${FEDORA_HOME} && \
     curl -o ${CATALINA_BASE}/webapps/fcrepo.war \
-    -L https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_VERSION}/fcrepo-webapp-plus${FEDORA_VERSION}.war && \
+    -L https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-${FEDORA_VERSION}/fcrepo-webapp-${FEDORA_VERSION}.war && \
     mkdir ${CATALINA_BASE}/webapps/fcrepo && \
     unzip -o ${CATALINA_BASE}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo && \
     rm -rf ${CATALINA_HOME}/webapps/*.war && \

--- a/Dockerfile.oracle-jdk
+++ b/Dockerfile.oracle-jdk
@@ -15,7 +15,7 @@ ENV FEDORA_HOME="/mnt/fedora-data" \
 RUN mkdir -p ${FEDORA_HOME} && \
     chown tomcat:tomcat ${FEDORA_HOME} && \
     curl -o ${CATALINA_BASE}/webapps/fcrepo.war \
-    -L https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FEDORA_VERSION}/fcrepo-webapp-plus${FEDORA_VERSION}.war && \
+    -L https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-${FEDORA_VERSION}/fcrepo-webapp-${FEDORA_VERSION}.war && \
     mkdir ${CATALINA_BASE}/webapps/fcrepo && \
     unzip -o ${CATALINA_BASE}/webapps/fcrepo.war -d ${CATALINA_HOME}/webapps/fcrepo && \
     rm -rf ${CATALINA_HOME}/webapps/*.war && \


### PR DESCRIPTION
Reverts Islandora-CLAW/claw-docker-fedora#5

Let's revert for now, because the filenames change depending on the version for webapp-plus
